### PR TITLE
Break the indexing loop if there is no more documents

### DIFF
--- a/hooks/meilisearch/utils.js
+++ b/hooks/meilisearch/utils.js
@@ -25,15 +25,15 @@ const addProducts = async (products) => {
 }
 
 const indexAllProducts = async (strapi) => {
-    let hasMore = true
     let _limit = 100
     let _start = 0
-    while (hasMore) {
+    while (true) {
         const products = await strapi.services.product.find({ _limit, _start, _sort: 'created_at:ASC' })
+        // break the loop if there is no more documents
+        if (products.length < 1) { break }
         console.log('Sending ' + products.length + ' products to Meilisearch')
         await addProducts(products)
         _start += products.length
-        hasMore = products.length > 0
     }
 }
 


### PR DESCRIPTION
This is a hotfix proposal of the issue [Meilisearch#1716](https://github.com/meilisearch/MeiliSearch/issues/1716) waiting for the next Meilisearch version.